### PR TITLE
Add Node.js chatbot backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+chat.db
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# AI
+# AI Chatbot Backend
+
+This repository now includes a simple Node.js + Express server that connects to the OpenAI API and stores chats in SQLite.
+
+## Setup
+1. Ensure Node.js is installed.
+2. Install dependencies (requires network access):
+   ```bash
+   npm install
+   ```
+3. Create a `.env` file with your OpenAI key:
+   ```env
+   OPENAI_API_KEY=your_openai_api_key_here
+   ```
+4. Start the server:
+   ```bash
+   npm start
+   ```
+
+## API
+- **POST /chat**: Send `{ "message": "hello", "userId": "123" }` and receive `{ "reply": "..." }`.
+
+Chat history is stored in `chat.db` for future analysis.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,76 @@
+require('dotenv').config();
+const express = require('express');
+const cors = require('cors');
+const { Configuration, OpenAIApi } = require('openai');
+const sqlite3 = require('sqlite3');
+
+const app = express();
+const db = new sqlite3.Database('chat.db');
+app.use(cors());
+app.use(express.json());
+
+// initialize database
+const initDb = () => {
+  db.run(`CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    userId TEXT,
+    message TEXT,
+    reply TEXT,
+    createdAt DATETIME DEFAULT CURRENT_TIMESTAMP
+  )`);
+};
+
+initDb();
+
+const configuration = new Configuration({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+const openai = new OpenAIApi(configuration);
+
+// Save message and reply
+const saveMessage = (userId, message, reply) => {
+  db.run(
+    'INSERT INTO messages (userId, message, reply) VALUES (?, ?, ?)',
+    [userId, message, reply]
+  );
+};
+
+// Bonus: Analyze chat history (placeholder)
+const analyzeHistory = () => {
+  return new Promise((resolve) => {
+    db.all('SELECT message FROM messages', (err, rows) => {
+      if (err) return resolve([]);
+      const counts = {};
+      rows.forEach((row) => {
+        counts[row.message] = (counts[row.message] || 0) + 1;
+      });
+      const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+      resolve(sorted.slice(0, 5));
+    });
+  });
+};
+
+app.post('/chat', async (req, res) => {
+  const { message, userId } = req.body;
+  if (!message || !userId) {
+    return res.status(400).json({ error: 'message and userId required' });
+  }
+
+  try {
+    const completion = await openai.createChatCompletion({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'user', content: message }
+      ]
+    });
+    const reply = completion.data.choices[0].message.content;
+    saveMessage(userId, message, reply);
+    res.json({ reply });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to get reply' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ai",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- set up Node.js project with Express and OpenAI integration
- store chat logs in SQLite
- ignore node_modules, .env and chat.db
- document setup and usage instructions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_688088a96698832aa4be976fddc20061