### PR TITLE
Add server loading OpenAI key from env

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,40 @@
+require('dotenv').config();
+const express = require('express');
+const fetch = require('node-fetch');
+const cors = require('cors');
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.post('/chat', async (req, res) => {
+  const { message } = req.body;
+  if (!message) {
+    return res.status(400).json({ error: 'message required' });
+  }
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: message }]
+      })
+    });
+
+    const data = await response.json();
+    const reply = data.choices && data.choices[0] && data.choices[0].message.content;
+    res.json({ reply });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to get reply' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- create `app.js` which loads the OpenAI key from `.env`
- send key in Authorization header when contacting OpenAI API

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68808c42e2b8832aa19cf14271dba0ac