### PR TITLE
Add basic OpenAI chat interaction

### DIFF
--- a/chatbot.html
+++ b/chatbot.html
@@ -130,6 +130,7 @@
     </div>
 
     <script>
+        const OPENAI_API_KEY = '';
         const botIcon = document.getElementById('bot-icon');
         const overlay = document.getElementById('overlay');
         const closeBtn = document.getElementById('close-btn');
@@ -143,13 +144,41 @@
 
         function sendMessage() {
             const text = chatInput.value.trim();
-            if (text) {
-                const div = document.createElement('div');
-                div.textContent = text;
-                chatArea.appendChild(div);
+            if (!text) return;
+            const userDiv = document.createElement('div');
+            userDiv.textContent = text;
+            userDiv.classList.add('user-message');
+            chatArea.appendChild(userDiv);
+
+            const botDiv = document.createElement('div');
+            botDiv.textContent = '...';
+            botDiv.classList.add('assistant-message');
+            chatArea.appendChild(botDiv);
+
+            chatArea.scrollTop = chatArea.scrollHeight;
+            chatInput.value = '';
+
+            fetch('https://api.openai.com/v1/chat/completions', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${OPENAI_API_KEY}`
+                },
+                body: JSON.stringify({
+                    model: 'gpt-4o',
+                    messages: [{ role: 'user', content: text }]
+                })
+            })
+            .then(res => res.json())
+            .then(data => {
+                const reply = data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content;
+                botDiv.textContent = reply || 'Failed to get reply.';
                 chatArea.scrollTop = chatArea.scrollHeight;
-                chatInput.value = '';
-            }
+            })
+            .catch(err => {
+                console.error(err);
+                botDiv.textContent = 'Error. Please try again.';
+            });
         }
 
         botIcon.addEventListener('click', () => toggleChat(true));

--- a/style.css
+++ b/style.css
@@ -87,3 +87,8 @@ header {
     text-align: right;
     margin: 2px 0;
 }
+
+.assistant-message {
+    text-align: left;
+    margin: 2px 0;
+}


### PR DESCRIPTION
## Summary
- add API key placeholder and send message code to `chatbot.html`
- style assistant messages in `style.css`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68818a636310832aa18286bf6e98cbe7