### PR TITLE
Refine chatbot error handling text

### DIFF
--- a/chatbot.html
+++ b/chatbot.html
@@ -151,7 +151,7 @@
             chatArea.appendChild(userDiv);
 
             const botDiv = document.createElement('div');
-            botDiv.textContent = '...';
+            botDiv.textContent = 'Thinking...';
             botDiv.classList.add('assistant-message');
             chatArea.appendChild(botDiv);
 
@@ -177,7 +177,7 @@
             })
             .catch(err => {
                 console.error(err);
-                botDiv.textContent = 'Error. Please try again.';
+                botDiv.textContent = 'Sorry, there was a problem. Please try again.';
             });
         }
 

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
             })
             .catch(err => {
                 console.error(err);
-                botP.textContent = 'Error. Please try again.';
+                botP.textContent = 'Sorry, there was a problem. Please try again.';
             });
         }
 


### PR DESCRIPTION
## Summary
- show friendly error message in chat interface
- display "Thinking..." in the alternate chatbot while waiting

## Testing
- `npm test` *(fails: no test specified)*
- `npm start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_68818c6c6c54832a806df22d88951ef6