### PR TITLE
Fix dotenv missing module error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+// Load environment variables from .env file
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');

--- a/package.json
+++ b/package.json
@@ -11,4 +11,8 @@
   "author": "",
   "license": "ISC",
   "type": "commonjs"
+  ,
+  "dependencies": {
+    "dotenv": "^16.0.0"
+  }
 }


### PR DESCRIPTION
## Summary
- add dotenv dependency
- load .env variables in `index.js`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_68818d50a538832a85a82a1f0bb17fa5