### PR TITLE
Add dotenv dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^16.3.1"
+  }
 }


### PR DESCRIPTION
## Summary
- install `dotenv` for Node.js project

## Testing
- `npm install dotenv` *(fails: 403 Forbidden due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_b_688192dc8cd0832aa3d70ca6ed4d10ec