### PR TITLE
Add chat API endpoint with OpenAI

### DIFF
--- a/chat-api.js
+++ b/chat-api.js
@@ -1,0 +1,36 @@
+require('dotenv').config();
+const express = require('express');
+
+const app = express();
+app.use(express.json());
+
+app.post('/api/chat', async (req, res) => {
+  const { message } = req.body;
+  if (typeof message !== 'string' || !message.trim()) {
+    return res.json({ reply: 'Failed to get reply.' });
+  }
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: message }]
+      })
+    });
+
+    const data = await response.json();
+    const reply = data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content;
+    if (!reply) throw new Error('No reply');
+    res.json({ reply });
+  } catch (err) {
+    console.error(err);
+    res.json({ reply: 'Failed to get reply.' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2"
   }
 }


### PR DESCRIPTION
## Summary
- provide `chat-api.js` Express server
- call OpenAI Chat Completions API using model `gpt-4o`
- update `package.json` dependencies

## Testing
- `node -c chat-api.js` *(fails: requires dotenv not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6881b02a0a84832ab3122e67f3085ec1