### PR TITLE
Improve error logging for chat API

### DIFF
--- a/chat-api.js
+++ b/chat-api.js
@@ -28,6 +28,9 @@ app.post('/api/chat', async (req, res) => {
     res.json({ reply });
   } catch (err) {
     console.error(err);
+    if (err.response) {
+      console.error(err.response.data || err.response);
+    }
     res.json({ reply: 'Failed to get reply.' });
   }
 });


### PR DESCRIPTION
## Summary
- log any available error response details when `/api/chat` fails

## Testing
- `node chat-api.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_6881b3de2238832aa09a5697bf7dcacf