### PR TITLE
Add Python-based document summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ This repository now includes a simple Node.js + Express server that connects to 
 - **POST /chat**: Send `{ "message": "hello", "userId": "123" }` and receive `{ "reply": "..." }`.
 
 Chat history is stored in `chat.db` for future analysis.
+
+## Text Summarizer (Python)
+This repo also includes a small Python script, `summarizer.py`, which leverages
+OpenAI's API to summarize a text file.
+
+1. Install the required dependencies (needs internet access):
+   ```bash
+   pip install openai python-dotenv
+   ```
+2. Ensure your `.env` file contains `OPENAI_API_KEY` as shown above.
+3. Run the script with the path to a text file:
+   ```bash
+   python summarizer.py document.txt
+   ```

--- a/summarizer.py
+++ b/summarizer.py
@@ -1,0 +1,33 @@
+from dotenv import load_dotenv
+import os
+import openai
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+def summarize_document(text: str, *, model: str = "gpt-3.5-turbo") -> str:
+    """Summarize the provided text using OpenAI."""
+    if not openai.api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable not set")
+
+    messages = [
+        {"role": "system", "content": "You summarize text provided by the user."},
+        {"role": "user", "content": f"Summarize the following text:\n{text}"}
+    ]
+
+    response = openai.ChatCompletion.create(model=model, messages=messages)
+    return response.choices[0].message.content.strip()
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: python summarizer.py <path_to_text_file>")
+        raise SystemExit(1)
+
+    file_path = sys.argv[1]
+    with open(file_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    summary = summarize_document(content)
+    print(summary)


### PR DESCRIPTION
## Summary
- add `summarizer.py` which loads the API key from `.env` and uses `openai` to summarize a text document
- document Python summarizer usage in `README.md`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `python summarizer.py README.md` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_688230bf274c832abf258a75ea39bed3